### PR TITLE
Ajout de la quantité

### DIFF
--- a/front/app/scripts/controllers/main.js
+++ b/front/app/scripts/controllers/main.js
@@ -49,7 +49,6 @@ angular.module('BabarApp')
 		$scope.main.products = res.data;
 	});
 	this.unsetProduct = function() {
-		this.product.quantity = 1;
 		this.productSearchText = '';
 		this.product = undefined;
 	};

--- a/front/app/views/main.html
+++ b/front/app/views/main.html
@@ -126,7 +126,7 @@
 				ng-show="main.product && !main.paymentIsOpen"
 				layout="column"
 				layout-align="center center">
-				<span>{{main.product.name}} x{{main.product.quantity}} {{main.product.price * main.product.quantity}}€</span>
+				<span>{{main.product.name}} x{{main.product.quantity}} {{100 * main.product.price * main.product.quantity / 100}}€</span>
 			</md-content>
 
 			<form

--- a/front/app/views/main.html
+++ b/front/app/views/main.html
@@ -45,18 +45,21 @@
 			</md-autocomplete>
 		</div>
 
-		<div flex layout="column" layout-align="center" layout-margin>
+		<div flex layout="row" layout-align="center" layout-margin>
 			<md-autocomplete
 				md-items="product in main.products | fuzzy:main.productSearchText:false:true"
 				md-search-text="main.productSearchText"
 				md-item-text="product.name"
 				md-selected-item-change="main.paymentIsOpen = false; main.setProduct(product.pk)"
 				md-autoselect="true"
-				placeholder="Product name?">
+				placeholder="Product name?" flex="90">
 				<span>{{product.name}}</span>
 			</md-autocomplete>
+			<md-input-container>
+			  <label>Quantity</label>
+			  <input type="number" ng-model="main.product.quantity" min="1" max="24" value="1" placeholder="1"/>
+</md-input-container>
 		</div>
-
 		<div flex layout="column" layout-align="center center" layout-margin>
 			<md-button
 				ng-disabled="!main.customer || !main.product"
@@ -123,7 +126,7 @@
 				ng-show="main.product && !main.paymentIsOpen"
 				layout="column"
 				layout-align="center center">
-				<span>{{main.product.name}} {{main.product.price}}€</span>
+				<span>{{main.product.name}} x{{main.product.quantity}} {{main.product.price * main.product.quantity}}€</span>
 			</md-content>
 
 			<form


### PR DESCRIPTION
Permet aux barmen de choisir la quantité d'un produit pour le client.
La quantité est à préciser entre 1 et 24 normalement.

**Si l'utilisateur peut payer pour 3 bières mais demande 5 bières, les 3 bières seront décomptées et une erreur apparaîtra lors du décompte du reste.** 

Le décompte est bien visible, le solde du compte se mettant bien à jour.